### PR TITLE
feat(iam): Add AWS Glue Policy to the IAM Role

### DIFF
--- a/modules/private-connection/README.md
+++ b/modules/private-connection/README.md
@@ -24,12 +24,14 @@
 | [aws_iam_role.ververica_cloud_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.glue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.kinesis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.msk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.private_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_policy_document.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.glue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kinesis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.msk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.private_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -43,6 +45,7 @@
 | <a name="input_dynamodb_table_arns"></a> [dynamodb\_table\_arns](#input\_dynamodb\_table\_arns) | A list of DynamoDB Table ARNs that Ververica Cloud will have access to | `list(string)` | `null` | no |
 | <a name="input_enable_dynamodb"></a> [enable\_dynamodb](#input\_enable\_dynamodb) | Enable the DynamoDB IAM Policies | `bool` | `false` | no |
 | <a name="input_enable_elasticache"></a> [enable\_elasticache](#input\_enable\_elasticache) | Enable the Elasticache IAM Policies | `bool` | `false` | no |
+| <a name="input_enable_glue"></a> [enable\_glue](#input\_enable\_glue) | Enable the AWS Glue IAM Policies | `bool` | `false` | no |
 | <a name="input_enable_kinesis"></a> [enable\_kinesis](#input\_enable\_kinesis) | Enable the Kinesis IAM Policies | `bool` | `false` | no |
 | <a name="input_enable_msk"></a> [enable\_msk](#input\_enable\_msk) | Enable the MSK IAM Policies | `bool` | `false` | no |
 | <a name="input_enable_private_connection"></a> [enable\_private\_connection](#input\_enable\_private\_connection) | Enable the VPC Endpoint IAM Policies | `bool` | `false` | no |

--- a/modules/private-connection/iam.tf
+++ b/modules/private-connection/iam.tf
@@ -31,7 +31,23 @@ resource "aws_iam_role" "ververica_cloud_iam_role" {
   max_session_duration  = var.max_session_duration
   permissions_boundary  = var.role_permissions_boundary_arn
   assume_role_policy    = data.aws_iam_policy_document.trust_policy.json
+}
 
+data "aws_iam_policy_document" "glue" {
+  count = var.enable_glue ? 1 : 0
+  statement {
+    sid       = "AWSGlueCatalogPolicy"
+    effect    = "Allow"
+    actions   = ["glue:*"]
+    resources = var.glue_arns == null ? ["*"] : var.glue_arns
+  }
+}
+
+resource "aws_iam_role_policy" "glue" {
+  count  = var.enable_glue ? 1 : 0
+  name   = "VervericaCloud-GlueCatalog-InlinePolicy"
+  role   = aws_iam_role.ververica_cloud_iam_role.id
+  policy = data.aws_iam_policy_document.glue[0].json
 }
 
 data "aws_iam_policy_document" "kinesis" {

--- a/modules/private-connection/outputs.tf
+++ b/modules/private-connection/outputs.tf
@@ -11,6 +11,7 @@ output "iam_role_arn" {
 output "enabled_policies" {
   description = "The IAM policies that are enabled for the IAM Role"
   value = {
+    Glue              = var.enable_glue
     Kinesis           = var.enable_kinesis
     DynamoDB          = var.enable_dynamodb
     S3                = var.enable_s3

--- a/modules/private-connection/variables.tf
+++ b/modules/private-connection/variables.tf
@@ -57,6 +57,18 @@ variable "tags" {
   default     = {}
 }
 
+variable "enable_glue" {
+  description = "Enable the AWS Glue Catalog Policies"
+  type        = bool
+  default     = false
+}
+
+variable "glue_arns" {
+  description = "A list of AWS Glue ARNs that Ververica Cloud will have access to"
+  type        = list(string)
+  default     = null
+}
+
 variable "enable_kinesis" {
   description = "Enable the Kinesis IAM Policies"
   type        = bool


### PR DESCRIPTION

Add AWS Glue policies:

```
      "glue:GetDatabase",
      "glue:CreateDatabase",
      "glue:GetTable",
      "glue:CreateTable",
      "glue:GetTables"
```

To the private connections IAM role.